### PR TITLE
 Unpack when dir name differs from component name

### DIFF
--- a/7/rootfs/libcomponent.sh
+++ b/7/rootfs/libcomponent.sh
@@ -59,6 +59,6 @@ component_unpack() {
         echo "Verifying package integrity"
         echo "$package_sha256  ${base_name}.tar.gz" | sha256sum --check -
     fi
-    tar --directory /opt/bitnami --extract --gunzip --file "${base_name}.tar.gz" --no-same-owner --strip-components=2 "${base_name}/files/${name}"
+    tar --directory /opt/bitnami --extract --gunzip --file "${base_name}.tar.gz" --no-same-owner --strip-components=2 "${base_name}/files/"
     rm "${base_name}.tar.gz"
 }


### PR DESCRIPTION
`component_unpack` was looking for files under `${base_name}/files/${name}`, but there are some containers that don't follow the same format.

This change is already implemented in `minideb-extras-base`: https://github.com/bitnami/minideb-extras-base/pull/248

It's been tested successfully with the mariadb 10.3 container.