### PR TITLE
Add debug_execute

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:7-slim
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 ENV IMAGE_OS=ol-7
 
-ENV BITNAMI_IMAGE_VERSION=7-r299
+ENV BITNAMI_IMAGE_VERSION=7-r300
 
 COPY rootfs /
 

--- a/7/rootfs/libos.sh
+++ b/7/rootfs/libos.sh
@@ -90,3 +90,20 @@ am_i_root() {
 get_total_memory() {
     echo $(($(grep MemTotal /proc/meminfo | awk '{print $2}') / 1024))
 }
+
+#########################
+# Redirects output to /dev/null if debug mode is disabled
+# Globals:
+#   BITNAMI_DEBUG
+# Arguments:
+#   $@ - Command to execute
+# Returns:
+#   None
+#########################
+debug_execute() {
+    if ${BITNAMI_DEBUG:-false}; then
+        "$@"
+    else
+        "$@" >/dev/null 2>&1
+    fi
+}


### PR DESCRIPTION
Add a function `debug_execute` that redirects the output of a command to `/dev/null` if `BITNAMI_DEBUG` is not set to true.