### PR TITLE
Add 'retry_while' function to 'libos.sh'

### DIFF
--- a/7/rootfs/libos.sh
+++ b/7/rootfs/libos.sh
@@ -115,7 +115,7 @@ debug_execute() {
 #   $2 - timeout (in seconds). Default: 60
 #   $3 - step (in seconds). Default: 5
 # Returns:
-#   None
+#   Boolean
 #########################
 retry_while() {
     local -r cmd="$1:?cmd is missing"

--- a/7/rootfs/libos.sh
+++ b/7/rootfs/libos.sh
@@ -107,3 +107,26 @@ debug_execute() {
         "$@" >/dev/null 2>&1
     fi
 }
+
+########################
+# Retries a command until timeout
+# Arguments:
+#   $1 - cmd (as a string)
+#   $2 - timeout (in seconds). Default: 60
+#   $3 - step (in seconds). Default: 5
+# Returns:
+#   None
+#########################
+retry_while() {
+    local -r cmd="$1:?cmd is missing"
+    local -r timeout="${2:-60}"
+    local -r step="${3:-5}"
+    local return_value=1
+
+    read -r -a command <<< "$cmd"
+    for ((i = 0 ; i <= timeout ; i+=step )); do
+        "${command[@]}" && return_value=0 && break
+        sleep "$step"
+    done
+    return $return_value
+}


### PR DESCRIPTION
This PR adds a new function 'retry_while' to the library 'libos.sh'.

This new function allows to retry a command until it returns a success code or it reaches the timeout. It returns true/false indicating whether it could successfully executed the command or not.