### PR TITLE
Fix 'libfs.sh' by loading 'liblog.sh' from the right path

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:7-slim
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 ENV IMAGE_OS=ol-7
 
-ENV BITNAMI_IMAGE_VERSION=7-r308
+ENV BITNAMI_IMAGE_VERSION=7-r309
 
 COPY rootfs /
 

--- a/7/rootfs/libfs.sh
+++ b/7/rootfs/libfs.sh
@@ -3,7 +3,7 @@
 # Library for file system actions
 
 # Load Generic Libraries
-. ./liblog.sh
+. /liblog.sh
 
 # Functions
 


### PR DESCRIPTION
This PR fixes 'libfs.sh' by loading 'liblog.sh' from the right path.