### PR TITLE
Always print 'module' and 'date' info

### DIFF
--- a/7/rootfs/liblog.sh
+++ b/7/rootfs/liblog.sh
@@ -31,7 +31,7 @@ stderr_print() {
 #   None
 #########################
 log() {
-    stderr_print "${BITNAMI_DEBUG:+${CYAN}${MODULE:-} ${MAGENTA}$(date "+%T.%2N ")}${RESET}${*}"
+    stderr_print "${CYAN}${MODULE:-} ${MAGENTA}$(date "+%T.%2N ")${RESET}${*}"
 }
 ########################
 # Log an 'info' message


### PR DESCRIPTION
We're not throwing information about the module and date in the `info`, `debug`, and `error` functions unless the **BITNAMI_DEBUG** environment variable is set. This PR removes that dependency.

Old format:

```
INFO  ==> Deploying PostgreSQL with persisted data...
INFO  ==> Starting PostgreSQL in background...
```

New format (with `MODULE=postgresql`):

```
postgresql 17:01:13.52 DEBUG ==> Ensuring expected directories/files exist...
postgresql 17:01:13.53 INFO  ==> Deploying PostgreSQL with persisted data...
postgresql 17:01:13.55 INFO  ==> Starting PostgreSQL in background...
```

New format (without setting `MODULE`):

```
 17:01:13.52 DEBUG ==> Ensuring expected directories/files exist...
 17:01:13.53 INFO  ==> Deploying PostgreSQL with persisted data...
 17:01:13.55 INFO  ==> Starting PostgreSQL in background...
```